### PR TITLE
Fix unusual feedback path causing an assertion failure when downloading results

### DIFF
--- a/src/e2e/resources/data/AdminAccountsPageE2ETest.json
+++ b/src/e2e/resources/data/AdminAccountsPageE2ETest.json
@@ -5,6 +5,12 @@
       "name": "Teammates Instr2",
       "email": "AAccounts.instr2@gmail.tmt",
       "readNotifications": {}
+    },
+    "AAccounts.instr3": {
+      "googleId": "tm.e2e.AAccounts.instr3",
+      "name": "Teammates Instr3",
+      "email": "AAccounts.instr3@gmail.tmt",
+      "readNotifications": {}
     }
   },
   "courses": {
@@ -57,7 +63,7 @@
       "name": "Teammates Instr2",
       "email": "AAccounts.instr2@gmail.tmt",
       "role": "Co-owner",
-      "isDisplayedToStudents": false,
+      "isDisplayedToStudents": true,
       "displayedName": "Co-owner",
       "privileges": {
         "courseLevel": {
@@ -81,6 +87,29 @@
       "email": "AAccounts.instr2@gmail.tmt",
       "role": "Co-owner",
       "isDisplayedToStudents": false,
+      "displayedName": "Co-owner",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "AAccounts.instr3-AAccounts.CS2103": {
+      "googleId": "tm.e2e.AAccounts.instr3",
+      "courseId": "tm.e2e.AAccounts.CS2103",
+      "name": "Teammates Instr3",
+      "email": "AAccounts.instr3@gmail.tmt",
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
       "displayedName": "Co-owner",
       "privileges": {
         "courseLevel": {

--- a/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
@@ -446,6 +446,19 @@ public final class InstructorPrivileges {
         return copy;
     }
 
+    /**
+     * Returns the list of sections the instructor has the specified privilege name.
+     */
+    public Map<String, InstructorPermissionSet> getSectionsWithPrivilege(String privilegeName) {
+        Map<String, InstructorPermissionSet> copy = new LinkedHashMap<>();
+        sectionLevel.forEach((key, value) -> {
+            if (isAllowedInSectionLevel(key, privilegeName)) {
+                copy.put(key, value.getCopy());
+            }
+        });
+        return copy;
+    }
+
     @Override
     public boolean equals(Object another) {
         if (!(another instanceof InstructorPrivileges)) {

--- a/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
@@ -4,8 +4,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
+import teammates.common.datatransfer.InstructorPermissionSet;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.util.Config;
@@ -356,6 +358,13 @@ public final class InstructorAttributes extends EntityAttributes<Instructor> {
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    /**
+     * Returns a list of sections this instructor has the specified privilege.
+     */
+    public Map<String, InstructorPermissionSet> getSectionsWithPrivilege(String privilegeName) {
+        return this.privileges.getSectionsWithPrivilege(privilegeName);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -469,11 +469,12 @@ public final class FeedbackQuestionsLogic {
             case SELF:
                 InstructorAttributes instructorGiver = courseRoster.getInstructorForEmail(possibleGiver);
 
+                // This is to resolve the only corner case
+                // where a session creator quits the course
                 if (instructorGiver == null) {
                     instructorGiver =
                             InstructorAttributes
                                     .builder(relatedQuestion.getCourseId(), possibleGiver)
-                                    .withName("Instructor has quit")
                                     .build();
                 }
 

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -469,7 +469,7 @@ public final class FeedbackQuestionsLogic {
             case SELF:
                 InstructorAttributes instructorGiver = courseRoster.getInstructorForEmail(possibleGiver);
 
-                // only when a session creator quits their course
+                // only happens when a session creator quits their course
                 if (instructorGiver == null) {
                     instructorGiver =
                             InstructorAttributes

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -468,6 +468,15 @@ public final class FeedbackQuestionsLogic {
             case INSTRUCTORS:
             case SELF:
                 InstructorAttributes instructorGiver = courseRoster.getInstructorForEmail(possibleGiver);
+
+                if (instructorGiver == null) {
+                    instructorGiver =
+                            InstructorAttributes
+                                    .builder(relatedQuestion.getCourseId(), possibleGiver)
+                                    .withName("Instructor has quit")
+                                    .build();
+                }
+
                 completeGiverRecipientMap
                         .computeIfAbsent(possibleGiver, key -> new HashSet<>())
                         .addAll(getRecipientsOfQuestion(

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -469,8 +469,7 @@ public final class FeedbackQuestionsLogic {
             case SELF:
                 InstructorAttributes instructorGiver = courseRoster.getInstructorForEmail(possibleGiver);
 
-                // This is to resolve the only corner case
-                // where a session creator quits the course
+                // only when a session creator quits their course
                 if (instructorGiver == null) {
                     instructorGiver =
                             InstructorAttributes

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -50,8 +50,8 @@ class DeleteInstructorAction extends Action {
             return new JsonResult("Instructor is successfully deleted.");
         }
 
-        // Deleting last instructor from the course is not allowed if you're not the admin
-        if (!userInfo.isAdmin && !hasAlternativeInstructor(courseId, instructor.getEmail())) {
+        // Deleting last instructor from the course is not allowed (even by admins)
+        if (!hasAlternativeInstructor(courseId, instructor.getEmail())) {
             throw new InvalidOperationException(
                     "The instructor you are trying to delete is the last instructor in the course. "
                     + "Deleting the last instructor from the course is not allowed.");

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -108,7 +108,10 @@ final class GateKeeper {
                                                   + instructor.getEmail() + "]");
         }
 
-        if (!instructor.isAllowedForPrivilege(privilegeName)) {
+        boolean instructorIsAllowedCoursePrivilege = instructor.isAllowedForPrivilege(privilegeName);
+        boolean instructorIsAllowedSectionPrivilege =
+                instructor.getSectionsWithPrivilege(privilegeName).size() != 0;
+        if (!instructorIsAllowedCoursePrivilege && !instructorIsAllowedSectionPrivilege) {
             throw new UnauthorizedAccessException("Course [" + course.getId() + "] is not accessible to instructor ["
                                                   + instructor.getEmail() + "] for privilege [" + privilegeName + "]");
         }

--- a/src/main/java/teammates/ui/webapi/GetStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentsAction.java
@@ -1,6 +1,8 @@
 package teammates.ui.webapi;
 
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
@@ -40,11 +42,28 @@ class GetStudentsAction extends Action {
     public JsonResult execute() {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String teamName = getRequestParamValue(Const.ParamsNames.TEAM_NAME);
+        InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.id);
+        String privilegeName = Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS;
+        boolean hasCoursePrivilege = instructor != null
+                && instructor.isAllowedForPrivilege(privilegeName);
+        boolean hasSectionPrivilege = instructor != null
+                && instructor.getSectionsWithPrivilege(privilegeName).size() != 0;
 
-        if (teamName == null) {
-            // request to get all students of a course by instructor
+        if (teamName == null && hasCoursePrivilege) {
+            // request to get all course students by instructor with course privilege
             List<StudentAttributes> studentsForCourse = logic.getStudentsForCourse(courseId);
             return new JsonResult(new StudentsData(studentsForCourse));
+        } else if (teamName == null && hasSectionPrivilege) {
+            // request to get students by instructor with section privilege
+            List<StudentAttributes> studentsForCourse = logic.getStudentsForCourse(courseId);
+            List<StudentAttributes> studentsToReturn = new LinkedList<>();
+            Set<String> sectionsWithViewPrivileges = instructor.getSectionsWithPrivilege(privilegeName).keySet();
+            studentsForCourse.forEach(student -> {
+                if (sectionsWithViewPrivileges.contains(student.getSection())) {
+                    studentsToReturn.add(student);
+                }
+            });
+            return new JsonResult(new StudentsData(studentsToReturn));
         } else {
             // request to get team members by current student
             List<StudentAttributes> studentsForTeam = logic.getStudentsForTeam(teamName, courseId);
@@ -52,7 +71,5 @@ class GetStudentsAction extends Action {
             studentsData.getStudents().forEach(StudentData::hideInformationForStudent);
             return new JsonResult(studentsData);
         }
-
     }
-
 }

--- a/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
@@ -97,7 +97,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     }
 
     @Test
-    protected void testExecute_adminDeletesLastInstructorByGoogleId_shouldPass() {
+    protected void testExecute_adminDeletesLastInstructorByGoogleId_shouldFail() {
         loginAsAdmin();
 
         InstructorAttributes instructor4 = typicalBundle.instructors.get("instructor4");
@@ -110,13 +110,12 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
 
         assertEquals(logic.getInstructorsForCourse(instructor4.getCourseId()).size(), 1);
 
-        DeleteInstructorAction deleteInstructorAction = getAction(submissionParams);
-        JsonResult response = getJsonResult(deleteInstructorAction);
+        InvalidOperationException ioe = verifyInvalidOperation(submissionParams);
+        assertEquals("The instructor you are trying to delete is the last instructor in the course. "
+                + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        MessageOutput msg = (MessageOutput) response.getOutput();
-        assertEquals("Instructor is successfully deleted.", msg.getMessage());
-
-        assertNull(logic.getInstructorForEmail(instructor4.getCourseId(), instructor4.getEmail()));
+        assertNotNull(logic.getInstructorForEmail(instructor4.getCourseId(), instructor4.getEmail()));
+        assertNotNull(logic.getInstructorForGoogleId(instructor4.getCourseId(), instructor4.getGoogleId()));
     }
 
     @Test


### PR DESCRIPTION
Fixes #11839

**Outline of Solution**

The issue happens when the creator of a session that has at least one question with this feedback path 'session creator -> anything' quits the course. Other instructors would then not be able to download questions that have that feedback path.

The explanation is that each session keeps track of its creator's email, and when searching for the exited creator in the course using the email, the search returns a `null` which is then fed into `FeedbackQuestionsLogic::getRecipientsOfQuestion` as `instructorGiver`. 

![image](https://user-images.githubusercontent.com/77197568/184413078-814a85af-bd46-47c1-b86a-c9a9fc65eb13.png)

Since this method requires either `instructorGiver` or `studentGiver` to be non-null, in the case of session creator `SELF`, `studentGiver` is set to `null` which means `instructorGiver` cannot be `null`.

![image](https://user-images.githubusercontent.com/77197568/184412602-f535555c-6b04-4587-b106-ece9faad2bef.png)

